### PR TITLE
Update Tab Completion

### DIFF
--- a/bean-add
+++ b/bean-add
@@ -126,7 +126,7 @@ def pluralize(number, word):
 
 # Completion
 def complete(text, state):
-	results = [x for x in data.vocab if x.lower().startswith(text.lower())] + [None]
+	results = [x for x in data.vocab if text.lower() in x.lower()] + [None]
 	return results[state]
 
 


### PR DESCRIPTION
Instead of having the tab completion only match to the beginning of the
word, match anywhere in the set.