### PR TITLE
Allow cycling through the readline completion suggestions.

### DIFF
--- a/bean-add
+++ b/bean-add
@@ -1451,7 +1451,9 @@ if data.journal != data.saved:
 	data.saved = data.journal.copy()
 
 # Set up the completer
-readline.parse_and_bind('tab: complete')
+readline.parse_and_bind('tab: menu-complete')
+readline.parse_and_bind('"\e[Z": menu-complete-backward')
+readline.parse_and_bind('set show-all-if-ambiguous on')
 
 readline.set_completer(complete)
 


### PR DESCRIPTION
Before this commit, after typing something and hitting TAB, readline would print all the matching words, but still require the user to fully type the remaining characters until there's only one matching completion. With this change, readline will still print all the matching words, but also allow cycling through them with TAB (or backwards with Shift-TAB) to quickly select the correct one without the need to type more characters.